### PR TITLE
Shell terminal instead of CLI

### DIFF
--- a/run-locally.html.md.erb
+++ b/run-locally.html.md.erb
@@ -19,7 +19,7 @@ $ java -jar build/libs/cf-sample-app-java-1.0.0.jar
 
 Open <a href="http://localhost:4567" target="_blank">http://localhost:4567</a> with your web browser. You should see your app running locally.
 
-To stop the app from running locally, in the CLI, press `Ctrl+C` to exit.
+To stop the app from running locally, in the shell terminal, press `Ctrl+C` to exit.
 
 <div style="text-align:center;margin:3em;">
   <a href="./push-changes.html" class="btn btn-primary">I can run my App locally</a>


### PR DESCRIPTION
- More precise
- CLI refers to the Command Line Interface, the client for accessing management APIs of Cloud Foundry